### PR TITLE
hyun/increase_top_navigation_user_drop_down_icon

### DIFF
--- a/lib/mazaryn_web/live/home_live/nav_component.ex
+++ b/lib/mazaryn_web/live/home_live/nav_component.ex
@@ -52,9 +52,9 @@ defmodule MazarynWeb.HomeLive.NavComponent do
                                     <div class="flex">
                                         <div class="flex rounded-full pr-6">
                                             <%= if @user.avatar_url do %>
-                                                <img src="https://placeimg.com/192/192/people" class="h-5 w-5 rounded-full"/>
+                                                <img src="https://placeimg.com/192/192/people" class="h-9 w-9 rounded-full"/>
                                             <% else %>
-                                                <img alt="Default user" src={Routes.static_path(@socket, "/images/default-user.svg")} class="h-5 w-5 rounded-full"/>
+                                                <img alt="Default user" src={Routes.static_path(@socket, "/images/default-user.svg")} class="h-9 w-9 rounded-full"/>
                                             <% end %>
                                             <%# <img src="https://placeimg.com/192/192/people" class="h-5 w-5 rounded-full"/> %>
                                         </div>


### PR DESCRIPTION

increased user profile icon size on top navigation


before

<img width="411" alt="Screen Shot 2022-08-20 at 4 18 39 PM" src="https://user-images.githubusercontent.com/3889468/185734051-fbe90796-15af-4cd7-b366-080fb9f0267d.png">



after


<img width="408" alt="Screen Shot 2022-08-20 at 4 18 26 PM" src="https://user-images.githubusercontent.com/3889468/185734045-52e49c13-3061-4888-9811-527211ababe6.png">

