### PR TITLE
deploy and skip using commit message [skip ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    branches: ["main"]
 
 env:
   MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
 
     # PURPOSE: skips Github actions, only use this when avoiding test and deploy.
     # Example usage for this to trigger:
-    # git commit -S -am "fix typo in html [skip ci/cd]"
+    # git commit -S -am "fix typo in html [skip ci]"
     name: check commit message for skipping build(s)
-    if: "contains(github.event.head_commit.message, '[skip ci/cd]')"
+    if: "contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: print message via cli
         run: echo "Skipping build, based from commit message"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Fly Deploy
 
 on:
   push:
-    branches: [ main ]
+    branches: ["main"]
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, '[deploy fly]')"
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master


### PR DESCRIPTION
the following commit message can be used for:

- skipping ci builds if not needed
- deploy via fly

By using commit message, we're triggering events so it doesn't automatically do every steps described in workflow file.

Example:

- for skipping ci builds: `git commit -m "fix typo in html [skip ci]`
- for triggering deploys: `git commit -m "fix search bar not working when empty input [deploy fly]`

**Note**: the square brackets (`[...]`) are important here, as it is being checked in the commit message itself.

[github docs](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push) `<--` find `head_commit`