### PR TITLE
Fix: Display chat notifications and messages on chat icon instead of …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ mazaryn-front
 
 .idea
 .iex.exs
+mazaryn/

--- a/lib/mazaryn/core/notif_event.ex
+++ b/lib/mazaryn/core/notif_event.ex
@@ -136,4 +136,7 @@ defmodule Core.NotifEvent do
   def mark_notif_as_read(notif_id) do
     :notifdb.mark_notif_as_read(notif_id)
   end
+  def get_all_unread(user_id) do
+  :notifdb.get_all_unread(user_id)
+end
 end

--- a/lib/mazaryn_web/live/chats_live/index.html.heex
+++ b/lib/mazaryn_web/live/chats_live/index.html.heex
@@ -14,6 +14,7 @@
       id="leftsidebar"
       user={@user}
       locale={@locale}
+      chat_notifs_count={0}
     />
   </div>
   <!-- middle column -->

--- a/lib/mazaryn_web/live/hashtag_live/index.html.heex
+++ b/lib/mazaryn_web/live/hashtag_live/index.html.heex
@@ -15,6 +15,7 @@
         id="leftsidebar"
         user={@current_user}
         locale={@locale}
+        chat_notifs_count={0} 
       />
     </div>
     <!-- middle column -->

--- a/lib/mazaryn_web/live/home_live/home.html.heex
+++ b/lib/mazaryn_web/live/home_live/home.html.heex
@@ -15,6 +15,7 @@
         id="leftsidebar"
         user={@user}
         locale={@locale}
+        chat_notifs_count={0}
       />
     </div>
     <!-- middle column -->

--- a/lib/mazaryn_web/live/home_live/left_sidebar_component.ex
+++ b/lib/mazaryn_web/live/home_live/left_sidebar_component.ex
@@ -13,7 +13,7 @@ defmodule MazarynWeb.HomeLive.LeftSidebarComponent do
             <ul>
               <li class="flex align-center items-center mx-2 mb-7">
                 <%= live_redirect to: Routes.live_path(@socket, MazarynWeb.HomeLive.Home, @locale),
-                             replace: false, class: "group flex align-center items-start text-base text-gray-500 font-semibold hover:text-blue-500" do %>
+                  replace: false, class: "group flex align-center items-start text-base text-gray-500 font-semibold hover:text-blue-500" do %>
                   <i>
                     <svg
                       class="h-5 w-5 mr-3.5 group-hover:fill-[#4385F5]"
@@ -34,6 +34,7 @@ defmodule MazarynWeb.HomeLive.LeftSidebarComponent do
                   </div>
                 <% end %>
               </li>
+
               <li class="flex align-center items-center mx-2 mb-7">
                 <.link
                   navigate={~p(/chats)}
@@ -65,13 +66,18 @@ defmodule MazarynWeb.HomeLive.LeftSidebarComponent do
                       </defs>
                     </svg>
                   </i>
-                  <div class="text-[#60616D] text-base leading-6 group-hover:text-[#4385F5]">
+                  <div class="relative text-[#60616D] text-base leading-6 group-hover:text-[#4385F5]">
                     <%= gettext("Chat") %>
-                  </div>
+                    <%= if @chat_notifs_count && @chat_notifs_count > 0 do %>
+                      <span class="absolute -top-2 -right-3 bg-red-500 text-white text-xs font-semibold px-1.5 py-0.5 rounded-full">
+                        <%= @chat_notifs_count %>
+                      </span>
+                    <% end %>
+                  </div> 
                 </.link>
               </li>
-
-              <li class="flex align-center items-center mx-2 mb-7">
+              
+               <li class="flex align-center items-center mx-2 mb-7">
                 <a
                   href="home"
                   class="group flex items-start text-base text-gray-500 font-semibold hover:text-blue-500"

--- a/lib/mazaryn_web/live/home_live/nav_component.ex
+++ b/lib/mazaryn_web/live/home_live/nav_component.ex
@@ -1,19 +1,46 @@
 defmodule MazarynWeb.HomeLive.NavComponent do
   use MazarynWeb, :live_component
   import Phoenix.Component
-
+  
   def mount(socket) do
     {:ok, socket}
   end
-
+  
   def update(%{user: user} = assigns, socket) do
-    notifs_count = Core.NotifEvent.count_unread(user.id)
-
+    all_notifs = Core.NotifEvent.get_all_unread(user.id)
+    
+    general_notifs_count = if Map.has_key?(assigns, :general_notifs_count) do
+      assigns.general_notifs_count
+    else
+      
+      {chat_notifs, general_notifs} = split_notifications(all_notifs)
+      length(general_notifs)
+    end
+    
     {:ok,
-     socket |> assign(assigns) |> assign(notifs_count: notifs_count) |> assign(current_path: "")}
+     socket 
+     |> assign(assigns) 
+     |> assign(general_notifs_count: general_notifs_count) 
+     |> assign(current_path: "")}
   end
-
+  
   def handle_path(socket) do
     {:noreply, socket}
+  end
+  
+  defp split_notifications(all_notifs) do
+    Enum.split_with(all_notifs, fn notification_tuple -> 
+      {:notif, _notif_id, _actor_id, _target_id, message, _time_stamp, _read, metadata, _extra} = notification_tuple
+      
+      is_chat_notification?(message, metadata)
+    end)
+  end
+  
+  defp is_chat_notification?(message, metadata) do
+
+    chat_type = metadata[:type] == "chat_message"
+    message_contains_chat = String.contains?(message, ["sent you a message", "messaged you", "chat"])
+    
+    chat_type || message_contains_chat
   end
 end

--- a/lib/mazaryn_web/live/home_live/nav_component.html.heex
+++ b/lib/mazaryn_web/live/home_live/nav_component.html.heex
@@ -49,9 +49,9 @@
             }>
               <%= Heroicons.icon("bell", class: "w-7 h-7 rounded-full fill-[#AAAAAA]") %>
             </.link>
-            <%= if @notifs_count > 0 do %>
+            <%= if @general_notifs_count && @general_notifs_count > 0 do %>
               <span class="absolute bg-teal-300 text-teal-900 px-2 py-1 text-xs font-bold rounded-full -top-3 -right-3">
-                <%= @notifs_count %>
+                <%= @general_notifs_count %>
               </span>
             <% end %>
           </span>

--- a/lib/mazaryn_web/live/home_live/notification.html.heex
+++ b/lib/mazaryn_web/live/home_live/notification.html.heex
@@ -15,6 +15,7 @@
         id="leftsidebar"
         user={@user}
         locale={@locale}
+        chat_notifs_count={0}
       />
     </div>
   </div>

--- a/lib/mazaryn_web/live/notification_live/index.html.heex
+++ b/lib/mazaryn_web/live/notification_live/index.html.heex
@@ -14,6 +14,7 @@
         id="leftside"
         user={@current_user}
         locale={@locale}
+        chat_notifs_count={0}
       />
     </div>
   </div>

--- a/lib/mazaryn_web/live/user_live/manage.html.heex
+++ b/lib/mazaryn_web/live/user_live/manage.html.heex
@@ -14,6 +14,7 @@
         id="leftside"
         user={@current_user}
         locale={@locale}
+        chat_notifs_count={0} 
       />
     </div>
 

--- a/lib/mazaryn_web/live/user_live/profile.html.heex
+++ b/lib/mazaryn_web/live/user_live/profile.html.heex
@@ -14,6 +14,7 @@
         id="leftside"
         user={@current_user}
         locale={@locale}
+        chat_notifs_count={0}
       />
     </div>
 

--- a/priv/repo/migrations/20250425220436_create_users_table.exs
+++ b/priv/repo/migrations/20250425220436_create_users_table.exs
@@ -1,0 +1,7 @@
+defmodule Mazaryn.Repo.Migrations.CreateUsersTable do
+  use Ecto.Migration
+
+  def change do
+
+  end
+end

--- a/src/otpcode/src/mnesia/notifdb.erl
+++ b/src/otpcode/src/mnesia/notifdb.erl
@@ -2,7 +2,7 @@
 -author("Zaryn Technologies").
 -export([insert/2, welcome/2, follow/3, mention/3, chat/3, get_single_notif/1, get_notif_message/1, get_all_notifs/1,
          get_all_notif_ids/1, get_username_by_id/1, delete_notif/1, get_notif_time/1, get_five_latest_notif_ids/1,
-         get_five_latest_notif_messages/1, mark_notif_as_read/1, count_unread/1]).
+         get_five_latest_notif_messages/1, mark_notif_as_read/1, count_unread/1, get_all_unread/1]).
 
 -include("../records.hrl").
 -include_lib("stdlib/include/qlc.hrl").
@@ -226,6 +226,22 @@ count_unread(UserID) ->
                 length(Objects);
             [] ->
                 0
+        end
+    end,
+    case mnesia:transaction(Fun) of
+        {atomic, Res} ->
+            Res;
+        {aborted, Reason} ->
+            {error, {aborted, Reason}}
+    end.
+
+  get_all_unread(UserID) ->
+    Fun = fun() ->
+        case mnesia:match_object(#notif{user_id = UserID, read = false, _ = '_'}) of
+            Objects when is_list(Objects) ->
+                Objects;
+            [] ->
+                {error, not_found}
         end
     end,
     case mnesia:transaction(Fun) of

--- a/src/otpcode/src/records.hrl
+++ b/src/otpcode/src/records.hrl
@@ -231,7 +231,8 @@
                call_type,             % video | audio
                call_status,           % initiated | ringing | connected | ended | failed
                call_link,
-               call_start_time,      
+               call_start_time,
+               read = false,      
                call_end_time, 
                timeout_ref,           % Timer reference for call timeout        
                data = #{} }).


### PR DESCRIPTION
Initially all the notifications including the messages and chat notifications, were being displayed in the general notification bell.
Now the chat notifications and messages from the users are displayed in the chat icon.